### PR TITLE
use ps as default quantum; add --M arg

### DIFF
--- a/Simulator.cpp
+++ b/Simulator.cpp
@@ -11,7 +11,7 @@ Simulator::Simulator(SST::ComponentId_t id, SST::Params& params)
   gVerbose        = params.find<bool>   ("verbose",        false);
   gArtificialWork = params.find<int64_t>("artificialWork", 0);
 
-  registerClock(std::to_string(timeToRun) + "s", new SST::Clock::Handler<Simulator>(this, &Simulator::clockTick));
+  registerClock(std::to_string(timeToRun) + "ps", new SST::Clock::Handler<Simulator>(this, &Simulator::clockTick));
 
   registerAsPrimaryComponent();
   primaryComponentDoNotEndSim();

--- a/gameoflife/gol.py
+++ b/gameoflife/gol.py
@@ -20,7 +20,7 @@ if args.M == -1:
 
 # We do a block-row partitioning of the game board.  Because the number of rows
 # might not be divisible my the number of MPI ranks we will have ranks 0
-# throuhg (args.M%numRanks) have (args.M / numRanks + 1) rows # and all
+# through (args.M%numRanks) have (args.M / numRanks + 1) rows # and all
 # subsequent ranks will have (args.M / numRanks).  IOW we evenly divide as best
 # we can, and then add an extra row to the first (args.M%numRanks) to get us to
 # our desired game board size.

--- a/pingpong.py
+++ b/pingpong.py
@@ -29,7 +29,7 @@ def link(x, y, direction):
   global numLinks
   if args.verbose:
     print("connect ", x.getFullName(), direction, "--", y.getFullName(), oppositeDir(direction))
-  sst.Link("link%i" % numLinks).connect( (x, "%sPort" % direction, "%is" % args.edgeDelay), (y, "%sPort" % oppositeDir(direction), "%is" % args.edgeDelay) )
+  sst.Link("link%i" % numLinks).connect( (x, "%sPort" % direction, "%ips" % args.edgeDelay), (y, "%sPort" % oppositeDir(direction), "%ips" % args.edgeDelay) )
   numLinks += 1
 
 # -----------------------------------------------------------------------------

--- a/pingpong_hyper.py
+++ b/pingpong_hyper.py
@@ -100,7 +100,7 @@ def hyperLink(g1,i1,j1, g2,i2,j2, port1Name, port2Name, isPass2=False):
 
   linkName = "l%s%d_%d" % ('' if not isPass2 else 'b', minId, maxId)
   if args.dryRun == -1:
-    sst.Link(linkName).connect( (ponger1, port1Name, "%is" % args.edgeDelay), (ponger2, port2Name, "%is" % args.edgeDelay) )
+    sst.Link(linkName).connect( (ponger1, port1Name, "%ips" % args.edgeDelay), (ponger2, port2Name, "%ips" % args.edgeDelay) )
 
 def prevDivisor(x, y):
   while True:


### PR DESCRIPTION
This PR updates the ping pong simulations to use 'ps' as the default simulated time unit on links and for the overall simulation time.

It also lets the user specify a rectangular area for conducting ping pong or game of life by passing in a `--M` parameter in addition to `--N`.

If the user only passes `--N` then both dimensions will be the same size (as it was prior to this PR). 